### PR TITLE
A litle bit of sugestions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,20 +57,15 @@ impl Applet {
     fn new(name: String) -> Option<Applet> {
         let mut appletpath = config_dir().unwrap();
 
-        appletpath.push(Path::new(&format!(
-            "instantstatus/applets/{}.ist.sh",
-            &name
-        )));
+        appletpath.push(format!("instantstatus/applets/{}.ist.sh", &name));
 
         let mut location = Appletlocation::Global;
 
         if appletpath.is_file() {
             location = Appletlocation::User;
         } else {
-            let globalpath = PathBuf::from(&format!(
-                "/usr/share/instantstatus/applets/{}.ist.sh",
-                &name
-            ));
+            let globalpath =
+                PathBuf::from(format!("/usr/share/instantstatus/applets/{}.ist.sh", &name));
             if globalpath.is_file() {
             } else {
                 eprintln!("applet {} does not exist", &name);
@@ -89,7 +84,7 @@ impl Applet {
 fn main() {
     let data = Statusdata::new();
     let mut confdir = config_dir().unwrap();
-    confdir.push(Path::new("instantstatus/applets"));
+    confdir.push("instantstatus/applets");
 
     if !confdir.exists() {
         std::fs::create_dir_all(confdir).unwrap();

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,26 +27,15 @@ pub struct Applet {
 }
 
 impl Applet {
-    // fn getpath(&self) -> String {
-    //     match self.location {
-    //         User => {
-    //             return String::from(&format("{}"))
-    //         }
-    //     }
-    //     String::from("asd")
-    // }
-
     fn render(&self, data: &Statusdata) -> Option<String> {
-
         let scriptpath = match &self.location {
-            User => format!(
+            Appletlocation::User => format!(
                 "{}/instantstatus/applets/{}.ist.sh",
                 &data.configpath, &self.script
             ),
-            Global => format!(
-                "/usr/share/instantstatus/applets/{}.ist.sh",
-                &self.script
-            ),
+            Appletlocation::Global => {
+                format!("/usr/share/instantstatus/applets/{}.ist.sh", &self.script)
+            }
         };
 
         match Command::new("bash")
@@ -55,7 +44,10 @@ impl Applet {
             .output()
         {
             Ok(output) => {
-                return Some(String::from(str::from_utf8(&output.stdout).unwrap()));
+                return Some(format!(
+                    "^c#ff0000^^f11^{}^f11^",
+                    String::from(str::from_utf8(&output.stdout).unwrap())
+                ));
             }
             Err(_) => {}
         };
@@ -69,8 +61,6 @@ impl Applet {
             "instantstatus/applets/{}.ist.sh",
             &name
         )));
-
-        println!("{}", appletpath.to_str().unwrap());
 
         let mut location = Appletlocation::Global;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,7 @@ impl Applet {
             Ok(output) => {
                 return Some(format!(
                     "^c#ff0000^^f11^{}^f11^",
-                    String::from(str::from_utf8(&output.stdout).unwrap())
+                    String::from_utf8(output.stdout).unwrap()
                 ));
             }
             Err(_) => {}


### PR DESCRIPTION
This PR isn't really meant for merging (it can be merged, but it's not the point of its existence), it's more of a list of hopefully helpful nitpicks.

---
#### Use `String::from_utf8()` instead of `String::from(str::from_utf8())` (https://github.com/instantOS/instantSTATUS/commit/da61c40ff39648c5044221edf0452009d8e16f2a)
###### Why:
- It just looks better
- `String::from_utf8(output)` is allocation free because it consumes `output`.
- `str::from_utf8(&output)` simply wraps `&output` so it does not allocate as well, but when we call `String::from` on a `&str` it will clone its contents to create a new `String` from it

---
#### Remove needless `Path::new` (https://github.com/instantOS/instantSTATUS/commit/3d2ff511b370327d1cfdf0ebccd21ff44637d6cc)
###### Why:
- `PathBuf::push` implementation is smart enough to figure out how to convert `String` and `&str` to `Path` for us, so there is no need to do this manually.
- It just looks better
---
#### Move `script_path` allocation (https://github.com/instantOS/instantSTATUS/commit/ae361ec70c9d8508096e6c5ef8a99bb86650d9e7)
###### Why:
- As far as I can tell, the path of a script will rarely or never change
- So we should just preallocate it in `new()` to minimize allocations during render.
- You could preallocate the command String too, but I think it would be an overkill, it's not like we need the fastest status in the world 😄.
---
#### It's generally a good practice to use [expect("Something went wrong!")](https://doc.rust-lang.org/stable/std/option/enum.Option.html#method.expect) over `unwrap()`
Simple example:
```rs
    let mut confdir = config_dir().expect("Could not find config dir");
    confdir.push("instantstatus/applets");

    if !confdir.exists() {
        std::fs::create_dir_all(confdir).expect("Failed to create applets dir");
    }
```
(I'm not saying that every unwrap has to be replaced, but it's nice to have some message attached to some of them, it's easier to debug this way)
